### PR TITLE
feat: :sparkles: add commit hooks with husky and lint-staged

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["next", "next/core-web-vitals", "prettier"],
+  "extends": ["next/core-web-vitals", "prettier"],
   "rules": {
     "@next/next/no-img-element": "off"
   }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
     "start": "next start",
     "lint": "next lint",
     "gen-demo": "plop",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint --fix"
+    ],
+    "*.{html,js,jsx}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@bradgarropy/next-seo": "^1.0.0",
@@ -25,6 +34,8 @@
     "eslint": "7.29.0",
     "eslint-config-next": "11.0.0",
     "eslint-config-prettier": "^8.3.0",
+    "husky": "^7.0.2",
+    "lint-staged": "^11.1.2",
     "plop": "^2.7.4",
     "prettier": "2.3.2"
   }


### PR DESCRIPTION
- Added Husky for commit hooks
- Lint-staged is used along with Husky just to make linting and formatting of only git staged files and not on the whole codebase
Closes #34