### PR TITLE
👌 IMPROVE: UI of copy to clipboard api page

### DIFF
--- a/components/core/form/InputField.js
+++ b/components/core/form/InputField.js
@@ -1,0 +1,17 @@
+/**
+ *
+ * @description A generic input field. Designed at an initial scale.
+ * @props all the props related to input field.
+ *
+ * NOTE: Please make sure that the className passed as prop with override the complete styling for now.
+ */
+const InputField = props => {
+  return (
+    <input
+      {...props}
+      className="tw-w-full tw-appearance-none tw-border-none leading-tight tw-py-3 tw-px-4 tw-rounded-tr-none tw-rounded-br-none tw-rounded-tl-4px tw-rounded-bl-4px tw-outline-none"
+    />
+  );
+};
+
+export default InputField;

--- a/components/core/form/InputFieldButton.js
+++ b/components/core/form/InputFieldButton.js
@@ -1,0 +1,22 @@
+/**
+ *
+ * @description styled button that can be used as an addon button with an input field
+ * @prop onClick - A function that is going to be called when the button is clicked.
+ * @prop children - We are treating the children as the button text here.
+ *
+ * NOTE: Please make sure that the className passed as prop with override the complete styling for now.
+ */
+
+const InputFieldButton = ({ onClick, children, ...rest }) => {
+  return (
+    <button
+      onClick={onClick}
+      className="tw-rounded-tl-none tw-rounded-bl-none tw-border-solid tw-border-t-1 tw-border-r-1 tw-border-b-1 tw-border-l-none tw-border-gray-300 tw-text-18px"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default InputFieldButton;

--- a/components/core/form/InputFieldWrapper.js
+++ b/components/core/form/InputFieldWrapper.js
@@ -1,0 +1,15 @@
+/**
+ *
+ * @description A wrapper that provides some border styles to the input field having no borders
+ *
+ * NOTE: Please make sure that the className passed as prop with override the complete styling for now.
+ */
+const InputFieldWrapper = ({ children }) => {
+  return (
+    <div className="tw-flex tw-border-solid tw-border-1 tw-border-gray-300 tw-rounded-4px tw-mb-5">
+      {children}
+    </div>
+  );
+};
+
+export default InputFieldWrapper;

--- a/components/index.js
+++ b/components/index.js
@@ -9,3 +9,7 @@ export { default as DemoInfo } from './util/DemoInfo';
 export { default as Creator } from './util/Creator';
 export { default as NotSupported } from './util/NotSupported';
 export { default as DemoSEO } from './util/DemoSEO';
+
+export { default as InputField } from './core/form/InputField';
+export { default as InputFieldButton } from './core/form/InputFieldButton';
+export { default as InputFieldWrapper } from './core/form/InputFieldWrapper';

--- a/pages/demos/clipboard/index.js
+++ b/pages/demos/clipboard/index.js
@@ -15,26 +15,61 @@ import { isSupported, performCopy, performPaste } from 'web-apis/clipboard';
 // demo info by id
 import { getDemoById } from 'utils/data/data-access';
 
+// Reusable component for Input Field wrapper.
+const InputFieldWrapper = ({ children }) => {
+  return (
+    <div className="tw-flex tw-border-solid tw-border-1 tw-border-gray-300 tw-rounded-4px tw-mb-5">
+      {children}
+    </div>
+  );
+};
+
+// Reusable styled input field.
+const InputField = props => {
+  return (
+    <input
+      {...props}
+      className="tw-w-full tw-appearance-none tw-border-none leading-tight tw-py-3 tw-px-4 tw-rounded-tr-none tw-rounded-br-none tw-rounded-tl-4px tw-rounded-bl-4px tw-outline-none"
+    />
+  );
+};
+
+// Reusable Button within the input wrapper
+const InputFieldButton = ({ onClick, children, ...rest }) => {
+  return (
+    <button
+      onClick={onClick}
+      className="tw-rounded-tl-none tw-rounded-bl-none tw-border-solid tw-border-t-1 tw-border-r-1 tw-border-b-1 tw-border-l-none tw-border-gray-300 tw-text-18px"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
 // Component that Renders the Demo UI
 const ToRender = () => {
   return (
     <div className="tw-flex tw-flex-col tw-items-center tw-justify-center">
-      <form>
-        <label htmlFor="copy-input">Copy</label>
-        <input
+      <InputFieldWrapper>
+        <InputField
           id="copy-input"
           type="text"
           name="copy"
           placeholder="Write Something..."
         />
-        <button onClick={performCopy}>Copy</button>
-      </form>
-
-      <form>
-        <label htmlFor="paste">Paste</label>
-        <input id="paste-input" type="text" name="paste" readOnly />
-        <button onClick={performPaste}>Paste</button>
-      </form>
+        <InputFieldButton onClick={performCopy}>Copy</InputFieldButton>
+      </InputFieldWrapper>
+      <InputFieldWrapper>
+        <InputField
+          id="paste-input"
+          type="text"
+          name="paste"
+          placeholder="Click paste"
+          readOnly
+        />
+        <InputFieldButton onClick={performPaste}>Paste</InputFieldButton>
+      </InputFieldWrapper>
     </div>
   );
 };

--- a/pages/demos/clipboard/index.js
+++ b/pages/demos/clipboard/index.js
@@ -6,46 +6,21 @@ import { useRouter } from 'next/router';
 // icons
 import { FiFileText, FiImage } from 'react-icons/fi';
 
-// demo information
-import { DemoInfo, DemoSEO, NotSupported } from 'components';
+// demo and form components
+import {
+  DemoInfo,
+  DemoSEO,
+  NotSupported,
+  InputFieldWrapper,
+  InputFieldButton,
+  InputField,
+} from 'components';
 
 // apis
 import { isSupported, performCopy, performPaste } from 'web-apis/clipboard';
 
 // demo info by id
 import { getDemoById } from 'utils/data/data-access';
-
-// Reusable component for Input Field wrapper.
-const InputFieldWrapper = ({ children }) => {
-  return (
-    <div className="tw-flex tw-border-solid tw-border-1 tw-border-gray-300 tw-rounded-4px tw-mb-5">
-      {children}
-    </div>
-  );
-};
-
-// Reusable styled input field.
-const InputField = props => {
-  return (
-    <input
-      {...props}
-      className="tw-w-full tw-appearance-none tw-border-none leading-tight tw-py-3 tw-px-4 tw-rounded-tr-none tw-rounded-br-none tw-rounded-tl-4px tw-rounded-bl-4px tw-outline-none"
-    />
-  );
-};
-
-// Reusable Button within the input wrapper
-const InputFieldButton = ({ onClick, children, ...rest }) => {
-  return (
-    <button
-      onClick={onClick}
-      className="tw-rounded-tl-none tw-rounded-bl-none tw-border-solid tw-border-t-1 tw-border-r-1 tw-border-b-1 tw-border-l-none tw-border-gray-300 tw-text-18px"
-      {...rest}
-    >
-      {children}
-    </button>
-  );
-};
 
 // Component that Renders the Demo UI
 const ToRender = () => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
       '30px': '30px',
     },
     borderWidth: {
+      'none': '0',
       '1': '1px',
       '3': '3px',
     },
@@ -18,6 +19,7 @@ module.exports = {
       '500px': '500px',
     },
     borderRadius: {
+      'none': '0',
       '0.5em': '0.5em',
       '4px': '4px',
       '5px': '5px',


### PR DESCRIPTION
# Description

- Fixes #66 
- Added some reusable components for input within the scope of copy to clipboard page.

New UI for Copy to Clipboard section: 

![image](https://user-images.githubusercontent.com/26999472/135760825-59638516-e440-4a68-a080-3dc98284856c.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/atapas/webapis-playground/blob/master/HOW-TO-ADD-DEMO.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
