### PR TITLE
refactor: replace searchAPI with useSearchApi hook to prevent infinit…

### DIFF
--- a/components/core/App.js
+++ b/components/core/App.js
@@ -1,36 +1,27 @@
-import React, { useState } from 'react';
-
-// import data from json
-import { getAllDemos } from 'utils/data/data-access';
+import React from 'react';
 
 // Demo component
 import { Demo } from '..';
 import { SearchBox } from './SearchBox';
 
+// useSearchApi hook
+import { useSearchApi } from '../../hooks/useSearchApi';
+
 const NOT_FOUND_TEXT = 'No matched demo found';
 
 const App = () => {
-  const [demos, setDemos] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  const searchAPI = (searchText) => {
-    const lowerSearchText = searchText.toLowerCase();
-    setLoading(true);
-    let searchedDemos = getAllDemos();
-    if (searchText) {
-      searchedDemos = searchedDemos
-        .filter(demo => demo.title?.toLowerCase().includes(lowerSearchText));
-    }
-
-    setDemos(searchedDemos);
-    setLoading(false);
-  };
+  const { demos, loading, searchText, setSearchText, setLoading } =
+    useSearchApi();
 
   return (
     <>
-      <SearchBox onSearch={searchAPI} />
+      <SearchBox
+        searchText={searchText}
+        setSearchText={setSearchText}
+        setLoading={setLoading}
+      />
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-center tw-p-10px">
-        {(!loading && demos.length > 0) ? (
+        {!loading && demos.length > 0 ? (
           demos.map((demo, index) => <Demo demo={demo} key={index} />)
         ) : (
           <div className="not-found">{NOT_FOUND_TEXT}</div>

--- a/components/core/SearchBox.js
+++ b/components/core/SearchBox.js
@@ -1,15 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 const PLACEHOLDER = 'Search by API names';
 
-export const SearchBox = ({ onSearch }) => {
-  const [searchText, setSearchText] = useState('');
-
-  useEffect(() => {
-    onSearch(searchText);
-  }, [searchText]);
-
-  const onSearchTextChange = event => setSearchText(event.target.value);
+export const SearchBox = ({ searchText, setSearchText, setLoading }) => {
+  const onSearchTextChange = event => {
+    setLoading(true);
+    setSearchText(event.target.value);
+  };
 
   const clearSearch = () => setSearchText('');
 

--- a/hooks/useSearchApi.js
+++ b/hooks/useSearchApi.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+// import data from json
+import { getAllDemos } from 'utils/data/data-access';
+
+export const useSearchApi = () => {
+  const [demos, setDemos] = useState(getAllDemos());
+  const [loading, setLoading] = useState();
+  const [searchText, setSearchText] = useState('');
+
+  useEffect(() => {
+    let allDemos = getAllDemos();
+
+    if (searchText) {
+      const lowerSearchText = searchText.toLowerCase();
+      allDemos = allDemos.filter(demo =>
+        demo.title?.toLowerCase().includes(lowerSearchText)
+      );
+    }
+
+    setLoading(false);
+    setDemos(allDemos);
+  }, [searchText]);
+
+  return {
+    demos,
+    loading,
+    searchText,
+    setSearchText,
+    setLoading,
+  };
+};

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,6 @@ module.exports = withPWA({
     runtimeCaching,
   },
   eslint: {
-    dirs: ['pages', 'components', 'web-apis', 'utils'],
+    dirs: ['pages', 'components', 'web-apis', 'utils', 'hooks'],
   },
 });


### PR DESCRIPTION
# Description
Currently eslint flags a warning on the `SearchBox` component due to `useEffect` not having `onSearch` in its dependency array. When you add it to the array, the search finctionality on the website breaks due to an infinite re-render. Potentially this happens because we end up with a circular new objects creation by triggering the `filter` array method within SearchBox.

In this PR I replaced the `searchAPI` method with a hook called `useSearchApi` which doesn't get called in `SearchBox` but rather in the parent component `App`. This way the filter doesn't happen in child components, it only depends on changes to `searchText` and it doesn't get triggered when the `demos` array changes.

Also, added the newly created `hooks` directory to eslint config in `next.config.js`.

Fixes #87 

## Type of change

- [x] Improvement

# How Has This Been Tested?

Running `build` and `lint` commands locally to confirm there are no errors. Also, ran the application locally to ensure search finctionality still works. Checked a few of the demos to make sure functionality there isn't affected, though it would be best if someone more familiar with the application confirms everything is as expected.

# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/atapas/webapis-playground/blob/master/HOW-TO-ADD-DEMO.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
