### PR TITLE
👌 Improved design: Network Information API page

### DIFF
--- a/pages/demos/network-information/index.js
+++ b/pages/demos/network-information/index.js
@@ -13,47 +13,68 @@ import { getDemoById } from 'utils/data/data-access';
 // Component that Renders the Demo UI
 const ToRender = () => {
   const [networkInfo] = useState(getNetworkInfo());
+  const UNKNOWN_STRING = 'Unknown';
+
   return (
-    <div className="tw-flex tw-flex-col tw-items-center tw-justify-center">
-      <ul id="network-info-main">
-        <li>
-          <span>Network Type: </span>
-          <span>
-            <b>{networkInfo.effectiveType}</b>
-          </span>
-        </li>
-        <li>
-          <span>Round Trip Time(rtt): </span>
-          <span>
-            <b>{networkInfo.rtt}</b>
-          </span>
-        </li>
-        <li>
-          <span>Bandwidth estimate(in MBPS): </span>
-          <span>
-            <b>{networkInfo.downlink}</b>
-          </span>
-        </li>
-        <li>
-          <span>Max Bandwidth estimate(in MBPS): </span>
-          <span>
-            <b>{networkInfo.downlinksMax}</b>
-          </span>
-        </li>
-        <li>
-          <span>Save data enabled: </span>
-          <span>
-            <b>{networkInfo.saveData ? 'Yes' : 'No'}</b>
-          </span>
-        </li>
-        <li>
-          <span>Device Connection Type: </span>
-          <span>
-            <b>{networkInfo.type}</b>
-          </span>
-        </li>
-      </ul>
-    </div>
+    <table className="tw-shadow-lg tw-bg-white tw-mt-4">
+      <thead>
+        <tr>
+          <th className="tw-bg-blue-100 tw-border tw-text-left tw-px-8 tw-py-2">
+            Property
+          </th>
+          <th className="tw-bg-blue-100 tw-border tw-text-left tw-px-8 tw-py-2">
+            Value
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">Network Type</td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.effectiveType || UNKNOWN_STRING}
+          </td>
+        </tr>
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">Round Trip Time(rtt)</td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.rtt || UNKNOWN_STRING}
+          </td>
+        </tr>
+
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">
+            Bandwidth estimate(in MBPS)
+          </td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.downlink || UNKNOWN_STRING}
+          </td>
+        </tr>
+
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">
+            Max Bandwidth estimate(in MBPS)
+          </td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.downlinksMax || UNKNOWN_STRING}
+          </td>
+        </tr>
+
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">Save data enabled</td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.saveData ? 'Yes' : 'No'}
+          </td>
+        </tr>
+
+        <tr>
+          <td className="tw-border tw-px-8 tw-py-2">Device Connection Type</td>
+          <td className="tw-border tw-px-8 tw-py-2">
+            {networkInfo.type || UNKNOWN_STRING}
+          </td>
+        </tr>
+      </tbody>
+    </table>
   );
 };
 


### PR DESCRIPTION

# Description
- The PR contains the fix for #95 
- The new UI has a table in which information has been shown
- If the information is not available, then we are showing the `Unknown` string (found some demos using this pattern)


New UI for the network information page:

![image](https://user-images.githubusercontent.com/26999472/137640844-28246792-d601-4984-9296-b24791d2209f.png)

Regarding the concern for adding more information, I have found one resource that tells all the available options on the API. 

Please See the interface for clarification: 

![image](https://user-images.githubusercontent.com/26999472/137640878-47a586c8-4693-44f7-abcf-7caa60c5e110.png)

For more information: https://wicg.github.io/netinfo/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/atapas/webapis-playground/blob/master/HOW-TO-ADD-DEMO.md) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
