### PR TITLE
Style "Can I Use" link

### DIFF
--- a/src/components/util/NotSupported.js
+++ b/src/components/util/NotSupported.js
@@ -4,7 +4,12 @@ const NotSupported = ({ canIUseURL }) => {
       <h1>OOPS!!!</h1>
       <h3>
         It seems your browser does not support this feature. Please check out{' '}
-        <a href={canIUseURL} target="_blank" rel="noreferrer">
+        <a
+          href={canIUseURL}
+          target="_blank"
+          rel="noreferrer"
+          className="tw-transition-all tw-text-blue-600 tw-hover:border-b-2 hover:tw-border-b-blue-600 tw-border-b-2"
+        >
           Can I Use
         </a>{' '}
         for more details.


### PR DESCRIPTION
# Description

I added styles to make the "Can I use" link discernable. 

Fixes #118 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this in Firefox to check whether or not the styles were implemented in the browser. 

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/atapas/webapis-playground/blob/master/HOW-TO-ADD-DEMO.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
