### PR TITLE
add new api: eyedropper api, close #158

### DIFF
--- a/src/modules/apis/data.ts
+++ b/src/modules/apis/data.ts
@@ -398,7 +398,7 @@ export const data: Array<Demo> = [
       apiDocURL: '',
       canIUseURL: 'https://caniuse.com/pagevisibility',
     },
-  }, //replace item here
+  },
   {
     id: 'selection-api',
     emoji: '🗒️',
@@ -417,6 +417,26 @@ export const data: Array<Demo> = [
       apiDocURL:
         'https://developer.mozilla.org/en-US/docs/Web/API/Selection_API',
       canIUseURL: 'https://caniuse.com/selection-api',
+    },
+  },
+  {
+    id: 'eyedropper-api',
+    emoji: '👁️‍🗨',
+    title: 'EyeDropper API',
+    description:
+      'The EyeDropper API provides a mechanism for creating an eyedropper tool. Using this tool, users can sample colors from their screens, including outside of the browser window.',
+    meta: {
+      author: {
+        name: 'Williams Samuel',
+        social: {
+          email: 'samwill300@gmail.com',
+          github: 'williamssam',
+          twitter: 'williams_codes',
+        },
+      },
+      apiDocURL:
+        'https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API',
+      canIUseURL: 'https://caniuse.com/mdn-api_eyedropper',
     },
   },
 ];

--- a/src/modules/apis/data.ts
+++ b/src/modules/apis/data.ts
@@ -438,5 +438,5 @@ export const data: Array<Demo> = [
         'https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API',
       canIUseURL: 'https://caniuse.com/mdn-api_eyedropper',
     },
-  },
+  }, //replace item here
 ];

--- a/src/modules/apis/eyedropper-api/index.ts
+++ b/src/modules/apis/eyedropper-api/index.ts
@@ -1,0 +1,31 @@
+export const hasSupport = (): boolean => Boolean('EyeDropper' in window);
+
+function run() {
+  const colorContainer = document.getElementById(
+    'color-container'
+  ) as HTMLDivElement;
+  const colorDiv = document.getElementById('color') as HTMLDivElement;
+  const colorHexCode = document.getElementById(
+    'color-hex-code'
+  ) as HTMLParagraphElement;
+
+  if (!window.EyeDropper) {
+    colorContainer.textContent =
+      'Your browser does not support the EyeDropper API 😔';
+    return;
+  }
+
+  const eyeDropper = new window.EyeDropper();
+
+  eyeDropper
+    .open()
+    .then((result: { sRGBHex: string }) => {
+      colorHexCode.textContent = result.sRGBHex;
+      colorDiv.style.backgroundColor = result.sRGBHex;
+    })
+    .catch((e: any) => {
+      console.log(e);
+    });
+}
+
+export default run;

--- a/src/modules/demos/eyedropper-api/index.tsx
+++ b/src/modules/demos/eyedropper-api/index.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/Button';
+import run, { hasSupport } from '../../apis/eyedropper-api';
+
+function EyedropperApi() {
+  if (!hasSupport) {
+    return <h1>Unsupported</h1>;
+  }
+
+  return (
+    <div>
+      <Button id="open-eyedropper" onClick={run}>
+        Open Eyedropper
+      </Button>
+
+      <div
+        className="tw-mt-5 tw-border tw-border-sky-500 tw-py-3 tw-px-5"
+        id="color-container"
+      >
+        {/* color */}
+        <div id="color" className="tw-w-32 tw-h-16 tw-rounded"></div>
+        {/* color hex code */}
+        <p className="tw-font-bold" id="color-hex-code"></p>
+      </div>
+    </div>
+  );
+}
+
+export default EyedropperApi;

--- a/src/types/demo.d.ts
+++ b/src/types/demo.d.ts
@@ -16,3 +16,10 @@ export interface Demo {
     canIUseURL: string;
   };
 }
+
+// Adds EyeDropper to the window global window interface
+declare global {
+  export interface Window {
+    EyeDropper: any; // 👈️ turn off type checking
+  }
+}

--- a/src/types/demo.d.ts
+++ b/src/types/demo.d.ts
@@ -17,7 +17,7 @@ export interface Demo {
   };
 }
 
-// Adds EyeDropper to the window global window interface
+// Adds EyeDropper to the global window object
 declare global {
   export interface Window {
     EyeDropper: any; // 👈️ turn off type checking

--- a/src/types/demo.d.ts
+++ b/src/types/demo.d.ts
@@ -19,7 +19,8 @@ export interface Demo {
 
 // Adds EyeDropper to the global window object
 declare global {
-  export interface Window {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
     EyeDropper: any; // 👈️ turn off type checking
   }
 }


### PR DESCRIPTION
# Description

The EyeDropper API provides a mechanism for creating an eyedropper tool. Using this tool, users can sample colors from their screens, including outside of the browser window.

Fixes #158 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/atapas/webapis-playground/blob/master/HOW-TO-ADD-DEMO.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
